### PR TITLE
fix(semantic-tokens): not being exported & auto generate docs

### DIFF
--- a/.changeset/honest-needles-switch.md
+++ b/.changeset/honest-needles-switch.md
@@ -1,0 +1,5 @@
+---
+'@signozhq/design-tokens': patch
+---
+
+Expose semantic tokens with docs

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"update-version": "changeset && changeset version",
 		"release": "pnpm build && changeset publish",
 		"prepare": "husky install",
-		"lint": "eslint . --ext .js,.jsx,.ts,.tsx --config eslint.config.js",
+		"lint": "eslint . --config eslint.config.js",
 		"format": "prettier --write .",
 		"pre-commit": "lint-staged",
 		"generate-tokens": "tsx ./scripts/generate-types-from-json.ts && style-dictionary build && tsx ./scripts/generate-semantic-tokens.ts && tsx ./scripts/generate-typography-styles.ts"

--- a/scripts/generate-semantic-tokens.ts
+++ b/scripts/generate-semantic-tokens.ts
@@ -18,12 +18,23 @@ const __dirname = dirname(__filename);
 /**
  * Type definition for semantic token JSON structure
  */
+interface TokenWithMetadata {
+	value: string;
+	description?: string;
+	usage?: string;
+	dontUse?: string;
+	category?: string;
+	group?: string;
+}
+
+type TokenValue = string | TokenWithMetadata;
+
 interface ThemeMode {
 	meta: {
 		'color-scheme': 'light' | 'dark';
 		selector?: string;
 	};
-	tokens: Record<string, string>;
+	tokens: Record<string, TokenValue>;
 }
 
 interface SemanticTokens {
@@ -33,18 +44,22 @@ interface SemanticTokens {
 	};
 }
 
+function getTokenValue(token: TokenValue): string {
+	return typeof token === 'string' ? token : token.value;
+}
+
 /**
  * Convert tokens object to CSS variable format
  * Tokens are already in var(--...) format, just need to add -- prefix to keys
  */
 function convertTokensToCSSFormat(
-	tokens: Record<string, string>,
+	tokens: Record<string, TokenValue>,
 ): Record<string, string> {
 	const cssTokens: Record<string, string> = {};
 
-	for (const [key, value] of Object.entries(tokens)) {
+	for (const [key, token] of Object.entries(tokens)) {
 		const cssKey = `--${key}`;
-		cssTokens[cssKey] = value;
+		cssTokens[cssKey] = getTokenValue(token);
 	}
 
 	return cssTokens;
@@ -134,7 +149,7 @@ ${darkBlock}
 /**
  * Generate TypeScript definitions for tokens
  */
-function generateStyleDefinitions(tokens: Record<string, string>): string {
+function generateStyleDefinitions(tokens: Record<string, TokenValue>): string {
 	const timestamp = new Date().toUTCString();
 
 	const styleEntries = Object.entries(tokens).map(([key]) => {
@@ -162,7 +177,7 @@ export type StyleType = typeof Style;
  * Generate Tailwind config definitions for tokens
  */
 function generateStyleTailwindDefinitions(
-	tokens: Record<string, string>,
+	tokens: Record<string, TokenValue>,
 ): string {
 	const timestamp = new Date().toUTCString();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export { default as colorTokens } from './tokens/color.json';
 export { default as spacingTokens } from './tokens/spacing.json';
 export { default as typographyTokens } from './tokens/typography.json';
 export { default as typographyStylesTokens } from './tokens/typography-styles.json';
+export { default as semanticTokens } from './tokens/semantic-tokens.json';

--- a/src/themes/signoz-tokens.css
+++ b/src/themes/signoz-tokens.css
@@ -1,7 +1,7 @@
 /**
  * Signoz Theme Tokens
  * DO NOT EDIT DIRECTLY - This file is auto-generated
- * Generated on Mon, 02 Feb 2026 06:36:25 GMT
+ * Generated on Fri, 27 Feb 2026 14:32:24 GMT
  */
 
 [data-theme='default'] {

--- a/src/tokens/semantic-tokens.json
+++ b/src/tokens/semantic-tokens.json
@@ -6,126 +6,758 @@
 				"selector": "[data-theme='default']"
 			},
 			"tokens": {
-				"background": "var(--bg-vanilla-200)",
-				"foreground": "var(--text-ink-400)",
-				"card": "var(--bg-vanilla-100)",
-				"card-foreground": "var(--text-ink-400)",
-				"popover": "var(--bg-vanilla-100)",
-				"popover-foreground": "var(--text-ink-400)",
-				"primary": "var(--bg-robin-500)",
-				"secondary": "var(--bg-vanilla-300)",
-				"muted": "var(--bg-vanilla-300)",
-				"muted-foreground": "var(--text-slate-50)",
-				"accent": "var(--bg-aqua-100)",
-				"accent-foreground": "var(--text-slate-400)",
-				"destructive": "var(--bg-cherry-500)",
-				"destructive-foreground": "var(--text-vanilla-100)",
-				"border": "var(--bg-vanilla-400)",
-				"input": "var(--bg-vanilla-400)",
-				"ring": "var(--bg-robin-500)",
-				"radius": "0.25rem",
-				"chart-1": "var(--bg-robin-500)",
-				"chart-2": "var(--bg-robin-600)",
-				"chart-3": "var(--bg-slate-300)",
-				"chart-4": "var(--bg-slate-400)",
-				"chart-5": "var(--bg-slate-500)",
-				"sidebar": "var(--bg-vanilla-300)",
-				"sidebar-foreground": "var(--text-ink-400)",
-				"sidebar-primary": "var(--bg-robin-500)",
-				"sidebar-primary-foreground": "var(--text-vanilla-100)",
-				"sidebar-accent": "var(--bg-aqua-100)",
-				"sidebar-accent-foreground": "var(--text-slate-400)",
-				"sidebar-border": "var(--bg-slate-400)",
-				"sidebar-ring": "var(--bg-robin-500)",
-				"font-sans": "'Inter'",
-				"font-serif": "'Open Sans'",
-				"font-mono": "'Geist Mono'",
-				"base-white": "var(--text-base-white)",
-				"base-black": "var(--text-base-black)",
-				"l1-background": "var(--bg-neutral-light-1000)",
-				"l2-background": "var(--bg-neutral-light-950)",
-				"l3-background": "var(--bg-neutral-light-800)",
-				"l1-background-hover": "var(--bg-neutral-light-900)",
-				"l2-background-hover": "var(--bg-neutral-light-700)",
-				"l3-background-hover": "var(--bg-neutral-light-700)",
-				"l1-foreground": "var(--text-neutral-light-50)",
-				"l1-foreground-hover": "var(--text-base-black)",
-				"l2-foreground": "var(--text-neutral-light-100)",
-				"l2-foreground-hover": "var(--text-neutral-light-50)",
-				"l3-foreground": "var(--text-neutral-light-200)",
-				"l3-foreground-hover": "var(--text-neutral-light-300)",
-				"l1-border": "var(--bg-neutral-light-900)",
-				"l2-border": "var(--bg-neutral-light-800)",
-				"l3-border": "var(--bg-neutral-light-700)",
-				"primary-background": "var(--bg-robin-500)",
-				"primary-background-hover": "var(--bg-robin-400)",
-				"primary-foreground": "var(--text-neutral-light-1000)",
-				"primary-foreground-hover": "var(--text-base-white)",
-				"secondary-background": "var(--bg-neutral-light-950)",
-				"secondary-background-hover": "var(--bg-neutral-light-700)",
-				"secondary-foreground": "var(--text-neutral-light-100)",
-				"secondary-foreground-hover": "var(--text-neutral-light-50)",
-				"secondary-border": "var(--bg-neutral-light-800)",
-				"success-background": "var(--bg-forest-600)",
-				"success-background-hover": "var(--bg-forest-400)",
-				"success-foreground": "var(--text-neutral-light-50)",
-				"success-foreground-hover": "var(--text-base-black)",
-				"warning-background": "var(--bg-amber-600)",
-				"warning-background-hover": "var(--bg-amber-400)",
-				"warning-foreground": "var(--text-neutral-light-50)",
-				"warning-foreground-hover": "var(--text-base-black)",
-				"danger-background": "var(--bg-cherry-500)",
-				"danger-background-hover": "var(--bg-cherry-400)",
-				"danger-foreground": "var(--text-neutral-light-1000)",
-				"danger-foreground-hover": "var(--text-base-white)",
-				"l1-background-transparent": "color-mix(in srgb, var(--bg-neutral-light-1000), transparent 100%)",
-				"l1-background-60": "color-mix(in srgb, var(--bg-neutral-light-1000), transparent 40%)",
-				"l2-background-transparent": "color-mix(in srgb, var(--bg-neutral-light-950), transparent 100%)",
-				"l2-background-60": "color-mix(in srgb, var(--bg-neutral-light-950), transparent 40%)",
-				"l3-background-transparent": "color-mix(in srgb, var(--bg-neutral-light-800), transparent 100%)",
-				"l3-background-60": "color-mix(in srgb, var(--bg-neutral-light-800), transparent 40%)",
-				"alert-strip-button-background": "color-mix(in srgb, var(--bg-ink-400), transparent 40%)",
-				"callout-primary-background": "color-mix(in srgb, var(--bg-robin-500), transparent 90%)",
-				"callout-primary-border": "color-mix(in srgb, var(--bg-robin-500), transparent 80%)",
-				"callout-primary-title": "var(--bg-robin-600)",
-				"callout-primary-description": "var(--bg-robin-600)",
-				"callout-primary-icon": "var(--bg-robin-300)",
-				"callout-success-background": "color-mix(in srgb, var(--bg-forest-600), transparent 90%)",
-				"callout-success-border": "color-mix(in srgb, var(--bg-forest-600), transparent 80%)",
-				"callout-success-title": "var(--bg-forest-600)",
-				"callout-success-description": "var(--bg-forest-600)",
-				"callout-success-icon": "var(--bg-forest-700)",
-				"callout-warning-background": "color-mix(in srgb, var(--bg-amber-600), transparent 90%)",
-				"callout-warning-border": "color-mix(in srgb, var(--bg-amber-600), transparent 80%)",
-				"callout-warning-title": "var(--bg-amber-700)",
-				"callout-warning-description": "var(--bg-amber-700)",
-				"callout-warning-icon": "var(--bg-amber-800)",
-				"callout-error-background": "color-mix(in srgb, var(--bg-cherry-500), transparent 90%)",
-				"callout-error-border": "color-mix(in srgb, var(--bg-cherry-500), transparent 80%)",
-				"callout-error-title": "var(--bg-cherry-600)",
-				"callout-error-description": "var(--bg-cherry-600)",
-				"callout-error-icon": "var(--bg-cherry-700)",
-				"accent-primary": "var(--bg-robin-500)",
-				"accent-primary-hover": "var(--bg-robin-400)",
-				"accent-primary-foreground": "var(--text-vanilla-100)",
-				"accent-forest": "var(--bg-forest-500)",
-				"accent-forest-hover": "var(--bg-forest-400)",
-				"accent-forest-foreground": "var(--text-vanilla-100)",
-				"accent-amber": "var(--bg-amber-500)",
-				"accent-amber-hover": "var(--bg-amber-400)",
-				"accent-amber-foreground": "var(--text-vanilla-100)",
-				"accent-cherry": "var(--bg-cherry-500)",
-				"accent-cherry-hover": "var(--bg-cherry-400)",
-				"accent-cherry-foreground": "var(--text-vanilla-100)",
-				"accent-aqua": "var(--bg-aqua-500)",
-				"accent-aqua-hover": "var(--bg-aqua-400)",
-				"accent-aqua-foreground": "var(--text-vanilla-100)",
-				"accent-sakura": "var(--bg-sakura-500)",
-				"accent-sakura-hover": "var(--bg-sakura-400)",
-				"accent-sakura-foreground": "var(--text-vanilla-100)",
-				"accent-sienna": "var(--bg-sienna-500)",
-				"accent-sienna-hover": "var(--bg-sienna-400)",
-				"accent-sienna-foreground": "var(--text-vanilla-100)"
+				"background": {
+					"value": "var(--bg-vanilla-200)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"foreground": {
+					"value": "var(--text-ink-400)",
+					"description": "",
+					"category": "foreground",
+					"group": "legacy"
+				},
+				"card": {
+					"value": "var(--bg-vanilla-100)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"card-foreground": {
+					"value": "var(--text-ink-400)",
+					"description": "",
+					"category": "foreground",
+					"group": "legacy"
+				},
+				"popover": {
+					"value": "var(--bg-vanilla-100)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"popover-foreground": {
+					"value": "var(--text-ink-400)",
+					"description": "",
+					"category": "foreground",
+					"group": "legacy"
+				},
+				"primary": {
+					"value": "var(--bg-robin-500)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"secondary": {
+					"value": "var(--bg-vanilla-300)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"muted": {
+					"value": "var(--bg-vanilla-300)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"muted-foreground": {
+					"value": "var(--text-slate-50)",
+					"description": "",
+					"category": "foreground",
+					"group": "legacy"
+				},
+				"accent": {
+					"value": "var(--bg-aqua-100)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"accent-foreground": {
+					"value": "var(--text-slate-400)",
+					"description": "",
+					"category": "foreground",
+					"group": "legacy"
+				},
+				"destructive": {
+					"value": "var(--bg-cherry-500)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"destructive-foreground": {
+					"value": "var(--text-vanilla-100)",
+					"description": "",
+					"category": "foreground",
+					"group": "legacy"
+				},
+				"border": {
+					"value": "var(--bg-vanilla-400)",
+					"description": "",
+					"category": "border",
+					"group": "legacy"
+				},
+				"input": {
+					"value": "var(--bg-vanilla-400)",
+					"description": "",
+					"category": "border",
+					"group": "legacy"
+				},
+				"ring": {
+					"value": "var(--bg-robin-500)",
+					"description": "",
+					"category": "border",
+					"group": "legacy"
+				},
+				"radius": {
+					"value": "0.25rem",
+					"description": "",
+					"category": "other",
+					"group": "legacy"
+				},
+				"chart-1": {
+					"value": "var(--bg-robin-500)",
+					"description": "",
+					"category": "background",
+					"group": "charts"
+				},
+				"chart-2": {
+					"value": "var(--bg-robin-600)",
+					"description": "",
+					"category": "background",
+					"group": "charts"
+				},
+				"chart-3": {
+					"value": "var(--bg-slate-300)",
+					"description": "",
+					"category": "background",
+					"group": "charts"
+				},
+				"chart-4": {
+					"value": "var(--bg-slate-400)",
+					"description": "",
+					"category": "background",
+					"group": "charts"
+				},
+				"chart-5": {
+					"value": "var(--bg-slate-500)",
+					"description": "",
+					"category": "background",
+					"group": "charts"
+				},
+				"sidebar": {
+					"value": "var(--bg-vanilla-300)",
+					"description": "",
+					"category": "background",
+					"group": "sidebar"
+				},
+				"sidebar-foreground": {
+					"value": "var(--text-ink-400)",
+					"description": "",
+					"category": "foreground",
+					"group": "sidebar"
+				},
+				"sidebar-primary": {
+					"value": "var(--bg-robin-500)",
+					"description": "",
+					"category": "background",
+					"group": "sidebar"
+				},
+				"sidebar-primary-foreground": {
+					"value": "var(--text-vanilla-100)",
+					"description": "",
+					"category": "foreground",
+					"group": "sidebar"
+				},
+				"sidebar-accent": {
+					"value": "var(--bg-aqua-100)",
+					"description": "",
+					"category": "background",
+					"group": "sidebar"
+				},
+				"sidebar-accent-foreground": {
+					"value": "var(--text-slate-400)",
+					"description": "",
+					"category": "foreground",
+					"group": "sidebar"
+				},
+				"sidebar-border": {
+					"value": "var(--bg-slate-400)",
+					"description": "",
+					"category": "border",
+					"group": "sidebar"
+				},
+				"sidebar-ring": {
+					"value": "var(--bg-robin-500)",
+					"description": "",
+					"category": "border",
+					"group": "sidebar"
+				},
+				"font-sans": {
+					"value": "'Inter'",
+					"description": "",
+					"category": "typography",
+					"group": "fonts"
+				},
+				"font-serif": {
+					"value": "'Open Sans'",
+					"description": "",
+					"category": "typography",
+					"group": "fonts"
+				},
+				"font-mono": {
+					"value": "'Geist Mono'",
+					"description": "",
+					"category": "typography",
+					"group": "fonts"
+				},
+				"base-white": {
+					"value": "var(--text-base-white)",
+					"description": "",
+					"category": "foreground",
+					"group": "base"
+				},
+				"base-black": {
+					"value": "var(--text-base-black)",
+					"description": "",
+					"category": "foreground",
+					"group": "base"
+				},
+				"l1-background": {
+					"value": "var(--bg-neutral-light-1000)",
+					"description": "Primary page background for the outermost container",
+					"usage": "Use for main app shell, page background, and root containers",
+					"dontUse": "Avoid for cards, modals, or nested elements - use l2 or l3 instead",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l2-background": {
+					"value": "var(--bg-neutral-light-950)",
+					"description": "Secondary background for cards and elevated surfaces",
+					"usage": "Use for cards, panels, sidebars, and first-level nested containers",
+					"dontUse": "Avoid for deeply nested elements - use l3 instead",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l3-background": {
+					"value": "var(--bg-neutral-light-800)",
+					"description": "Tertiary background for nested elements within cards",
+					"usage": "Use for inputs, dropdowns, and elements nested inside l2 containers",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l1-background-hover": {
+					"value": "var(--bg-neutral-light-900)",
+					"description": "Hover state for l1-background elements",
+					"usage": "Use for interactive elements on l1 background surfaces",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l2-background-hover": {
+					"value": "var(--bg-neutral-light-700)",
+					"description": "Hover state for l2-background elements",
+					"usage": "Use for interactive elements on l2 background surfaces",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l3-background-hover": {
+					"value": "var(--bg-neutral-light-700)",
+					"description": "Hover state for l3-background elements",
+					"usage": "Use for interactive elements on l3 background surfaces",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l1-foreground": {
+					"value": "var(--text-neutral-light-50)",
+					"description": "Primary text color for l1 backgrounds",
+					"usage": "Use for headings and primary text on l1 surfaces",
+					"category": "foreground",
+					"group": "surface-levels"
+				},
+				"l1-foreground-hover": {
+					"value": "var(--text-base-black)",
+					"description": "Hover text color for interactive elements on l1",
+					"category": "foreground",
+					"group": "surface-levels"
+				},
+				"l2-foreground": {
+					"value": "var(--text-neutral-light-100)",
+					"description": "Secondary text color for l2 backgrounds",
+					"usage": "Use for body text and secondary content on l2 surfaces",
+					"category": "foreground",
+					"group": "surface-levels"
+				},
+				"l2-foreground-hover": {
+					"value": "var(--text-neutral-light-50)",
+					"description": "Hover text color for interactive elements on l2",
+					"category": "foreground",
+					"group": "surface-levels"
+				},
+				"l3-foreground": {
+					"value": "var(--text-neutral-light-200)",
+					"description": "Tertiary text color for l3 backgrounds and muted text",
+					"usage": "Use for captions, labels, and less prominent text",
+					"category": "foreground",
+					"group": "surface-levels"
+				},
+				"l3-foreground-hover": {
+					"value": "var(--text-neutral-light-300)",
+					"description": "Hover text color for interactive elements on l3",
+					"category": "foreground",
+					"group": "surface-levels"
+				},
+				"l1-border": {
+					"value": "var(--bg-neutral-light-900)",
+					"description": "Border color for elements on l1 backgrounds",
+					"usage": "Use for dividers and borders separating l1 content",
+					"category": "border",
+					"group": "surface-levels"
+				},
+				"l2-border": {
+					"value": "var(--bg-neutral-light-800)",
+					"description": "Border color for elements on l2 backgrounds",
+					"usage": "Use for card borders and dividers within cards",
+					"category": "border",
+					"group": "surface-levels"
+				},
+				"l3-border": {
+					"value": "var(--bg-neutral-light-700)",
+					"description": "Border color for elements on l3 backgrounds",
+					"usage": "Use for input borders and nested element dividers",
+					"category": "border",
+					"group": "surface-levels"
+				},
+				"primary-background": {
+					"value": "var(--bg-robin-500)",
+					"description": "Primary action background color",
+					"usage": "Use for primary buttons, CTAs, and main interactive elements",
+					"category": "background",
+					"group": "actions"
+				},
+				"primary-background-hover": {
+					"value": "var(--bg-robin-400)",
+					"description": "Hover state for primary action elements",
+					"category": "background",
+					"group": "actions"
+				},
+				"primary-foreground": {
+					"value": "var(--text-neutral-light-1000)",
+					"description": "Text color for primary action elements",
+					"usage": "Use for text on primary buttons and CTAs",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"primary-foreground-hover": {
+					"value": "var(--text-base-white)",
+					"description": "Hover text color for primary action elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"secondary-background": {
+					"value": "var(--bg-neutral-light-950)",
+					"description": "Secondary action background color",
+					"usage": "Use for secondary buttons and less prominent actions",
+					"category": "background",
+					"group": "actions"
+				},
+				"secondary-background-hover": {
+					"value": "var(--bg-neutral-light-700)",
+					"description": "Hover state for secondary action elements",
+					"category": "background",
+					"group": "actions"
+				},
+				"secondary-foreground": {
+					"value": "var(--text-neutral-light-100)",
+					"description": "Text color for secondary action elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"secondary-foreground-hover": {
+					"value": "var(--text-neutral-light-50)",
+					"description": "Hover text color for secondary action elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"secondary-border": {
+					"value": "var(--bg-neutral-light-800)",
+					"description": "Border color for secondary buttons",
+					"usage": "Use for outlined secondary buttons",
+					"category": "border",
+					"group": "actions"
+				},
+				"success-background": {
+					"value": "var(--bg-forest-600)",
+					"description": "Success action background color",
+					"usage": "Use for success states, confirmations, and positive actions",
+					"category": "background",
+					"group": "actions"
+				},
+				"success-background-hover": {
+					"value": "var(--bg-forest-400)",
+					"description": "Hover state for success elements",
+					"category": "background",
+					"group": "actions"
+				},
+				"success-foreground": {
+					"value": "var(--text-neutral-light-50)",
+					"description": "Text color for success action elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"success-foreground-hover": {
+					"value": "var(--text-base-black)",
+					"description": "Hover text color for success elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"warning-background": {
+					"value": "var(--bg-amber-600)",
+					"description": "Warning action background color",
+					"usage": "Use for warning states and cautionary actions",
+					"category": "background",
+					"group": "actions"
+				},
+				"warning-background-hover": {
+					"value": "var(--bg-amber-400)",
+					"description": "Hover state for warning elements",
+					"category": "background",
+					"group": "actions"
+				},
+				"warning-foreground": {
+					"value": "var(--text-neutral-light-50)",
+					"description": "Text color for warning action elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"warning-foreground-hover": {
+					"value": "var(--text-base-black)",
+					"description": "Hover text color for warning elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"danger-background": {
+					"value": "var(--bg-cherry-500)",
+					"description": "Danger action background color",
+					"usage": "Use for destructive actions, errors, and critical warnings",
+					"category": "background",
+					"group": "actions"
+				},
+				"danger-background-hover": {
+					"value": "var(--bg-cherry-400)",
+					"description": "Hover state for danger elements",
+					"category": "background",
+					"group": "actions"
+				},
+				"danger-foreground": {
+					"value": "var(--text-neutral-light-1000)",
+					"description": "Text color for danger action elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"danger-foreground-hover": {
+					"value": "var(--text-base-white)",
+					"description": "Hover text color for danger elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"l1-background-transparent": {
+					"value": "color-mix(in srgb, var(--bg-neutral-light-1000), transparent 100%)",
+					"description": "",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l1-background-60": {
+					"value": "color-mix(in srgb, var(--bg-neutral-light-1000), transparent 40%)",
+					"description": "",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l2-background-transparent": {
+					"value": "color-mix(in srgb, var(--bg-neutral-light-950), transparent 100%)",
+					"description": "",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l2-background-60": {
+					"value": "color-mix(in srgb, var(--bg-neutral-light-950), transparent 40%)",
+					"description": "",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l3-background-transparent": {
+					"value": "color-mix(in srgb, var(--bg-neutral-light-800), transparent 100%)",
+					"description": "",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l3-background-60": {
+					"value": "color-mix(in srgb, var(--bg-neutral-light-800), transparent 40%)",
+					"description": "",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"alert-strip-button-background": {
+					"value": "color-mix(in srgb, var(--bg-ink-400), transparent 40%)",
+					"description": "",
+					"category": "background",
+					"group": "alerts"
+				},
+				"callout-primary-background": {
+					"value": "color-mix(in srgb, var(--bg-robin-500), transparent 90%)",
+					"description": "Background for informational callout boxes",
+					"usage": "Use for info callouts, tips, and general announcements",
+					"category": "background",
+					"group": "callouts"
+				},
+				"callout-primary-border": {
+					"value": "color-mix(in srgb, var(--bg-robin-500), transparent 80%)",
+					"description": "Border for informational callout boxes",
+					"category": "border",
+					"group": "callouts"
+				},
+				"callout-primary-title": {
+					"value": "var(--bg-robin-600)",
+					"description": "Title text color for informational callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-primary-description": {
+					"value": "var(--bg-robin-600)",
+					"description": "Description text color for informational callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-primary-icon": {
+					"value": "var(--bg-robin-300)",
+					"description": "Icon color for informational callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-success-background": {
+					"value": "color-mix(in srgb, var(--bg-forest-600), transparent 90%)",
+					"description": "Background for success callout boxes",
+					"usage": "Use for success messages and positive confirmations",
+					"category": "background",
+					"group": "callouts"
+				},
+				"callout-success-border": {
+					"value": "color-mix(in srgb, var(--bg-forest-600), transparent 80%)",
+					"description": "Border for success callout boxes",
+					"category": "border",
+					"group": "callouts"
+				},
+				"callout-success-title": {
+					"value": "var(--bg-forest-600)",
+					"description": "Title text color for success callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-success-description": {
+					"value": "var(--bg-forest-600)",
+					"description": "Description text color for success callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-success-icon": {
+					"value": "var(--bg-forest-700)",
+					"description": "Icon color for success callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-warning-background": {
+					"value": "color-mix(in srgb, var(--bg-amber-600), transparent 90%)",
+					"description": "Background for warning callout boxes",
+					"usage": "Use for warning messages and cautionary information",
+					"category": "background",
+					"group": "callouts"
+				},
+				"callout-warning-border": {
+					"value": "color-mix(in srgb, var(--bg-amber-600), transparent 80%)",
+					"description": "Border for warning callout boxes",
+					"category": "border",
+					"group": "callouts"
+				},
+				"callout-warning-title": {
+					"value": "var(--bg-amber-700)",
+					"description": "Title text color for warning callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-warning-description": {
+					"value": "var(--bg-amber-700)",
+					"description": "Description text color for warning callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-warning-icon": {
+					"value": "var(--bg-amber-800)",
+					"description": "Icon color for warning callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-error-background": {
+					"value": "color-mix(in srgb, var(--bg-cherry-500), transparent 90%)",
+					"description": "Background for error callout boxes",
+					"usage": "Use for error messages and critical information",
+					"category": "background",
+					"group": "callouts"
+				},
+				"callout-error-border": {
+					"value": "color-mix(in srgb, var(--bg-cherry-500), transparent 80%)",
+					"description": "Border for error callout boxes",
+					"category": "border",
+					"group": "callouts"
+				},
+				"callout-error-title": {
+					"value": "var(--bg-cherry-600)",
+					"description": "Title text color for error callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-error-description": {
+					"value": "var(--bg-cherry-600)",
+					"description": "Description text color for error callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-error-icon": {
+					"value": "var(--bg-cherry-700)",
+					"description": "Icon color for error callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"accent-primary": {
+					"value": "var(--bg-robin-500)",
+					"description": "Primary brand accent color",
+					"usage": "Use for links, highlights, and brand elements",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-primary-hover": {
+					"value": "var(--bg-robin-400)",
+					"description": "Hover state for primary accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-primary-foreground": {
+					"value": "var(--text-vanilla-100)",
+					"description": "Text color on primary accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				},
+				"accent-forest": {
+					"value": "var(--bg-forest-500)",
+					"description": "Green accent for success and positive indicators",
+					"usage": "Use for success badges, positive trends, and status indicators",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-forest-hover": {
+					"value": "var(--bg-forest-400)",
+					"description": "Hover state for forest accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-forest-foreground": {
+					"value": "var(--text-vanilla-100)",
+					"description": "Text color on forest accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				},
+				"accent-amber": {
+					"value": "var(--bg-amber-500)",
+					"description": "Yellow/orange accent for warnings and attention",
+					"usage": "Use for warning badges, pending states, and attention indicators",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-amber-hover": {
+					"value": "var(--bg-amber-400)",
+					"description": "Hover state for amber accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-amber-foreground": {
+					"value": "var(--text-vanilla-100)",
+					"description": "Text color on amber accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				},
+				"accent-cherry": {
+					"value": "var(--bg-cherry-500)",
+					"description": "Red accent for errors and critical states",
+					"usage": "Use for error badges, negative trends, and critical indicators",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-cherry-hover": {
+					"value": "var(--bg-cherry-400)",
+					"description": "Hover state for cherry accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-cherry-foreground": {
+					"value": "var(--text-vanilla-100)",
+					"description": "Text color on cherry accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				},
+				"accent-aqua": {
+					"value": "var(--bg-aqua-500)",
+					"description": "Cyan/teal accent for informational elements",
+					"usage": "Use for info badges, links, and data visualization",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-aqua-hover": {
+					"value": "var(--bg-aqua-400)",
+					"description": "Hover state for aqua accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-aqua-foreground": {
+					"value": "var(--text-vanilla-100)",
+					"description": "Text color on aqua accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				},
+				"accent-sakura": {
+					"value": "var(--bg-sakura-500)",
+					"description": "Pink accent for decorative elements",
+					"usage": "Use for tags, labels, and data visualization variety",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-sakura-hover": {
+					"value": "var(--bg-sakura-400)",
+					"description": "Hover state for sakura accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-sakura-foreground": {
+					"value": "var(--text-vanilla-100)",
+					"description": "Text color on sakura accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				},
+				"accent-sienna": {
+					"value": "var(--bg-sienna-500)",
+					"description": "Brown/orange accent for earthy elements",
+					"usage": "Use for tags, labels, and data visualization variety",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-sienna-hover": {
+					"value": "var(--bg-sienna-400)",
+					"description": "Hover state for sienna accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-sienna-foreground": {
+					"value": "var(--text-vanilla-100)",
+					"description": "Text color on sienna accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				}
 			}
 		},
 		"dark": {
@@ -134,125 +766,752 @@
 				"selector": "[data-theme='default'].dark"
 			},
 			"tokens": {
-				"background": "var(--bg-ink-500)",
-				"foreground": "var(--text-vanilla-400)",
-				"card": "var(--bg-ink-400)",
-				"card-foreground": "var(--text-vanilla-100)",
-				"popover": "var(--bg-ink-400)",
-				"popover-foreground": "var(--text-vanilla-100)",
-				"primary": "var(--bg-robin-500)",
-				"secondary": "var(--bg-slate-500)",
-				"muted": "var(--bg-slate-500)",
-				"muted-foreground": "var(--text-vanilla-400)",
-				"accent": "var(--bg-slate-300)",
-				"accent-foreground": "var(--text-vanilla-100)",
-				"destructive": "var(--bg-cherry-500)",
-				"destructive-foreground": "var(--text-ink-500)",
-				"border": "var(--bg-slate-400)",
-				"input": "var(--bg-slate-300)",
-				"ring": "var(--bg-robin-500)",
-				"radius": "0.25rem",
-				"chart-1": "var(--bg-robin-400)",
-				"chart-2": "var(--bg-robin-500)",
-				"chart-3": "var(--bg-robin-600)",
-				"chart-4": "var(--bg-slate-200)",
-				"chart-5": "var(--bg-slate-300)",
-				"sidebar": "var(--bg-slate-500)",
-				"sidebar-foreground": "var(--text-vanilla-400)",
-				"sidebar-primary": "var(--bg-robin-500)",
-				"sidebar-primary-foreground": "var(--text-ink-500)",
-				"sidebar-accent": "var(--bg-slate-400)",
-				"sidebar-accent-foreground": "var(--text-vanilla-400)",
-				"sidebar-border": "var(--bg-slate-500)",
-				"sidebar-ring": "var(--bg-robin-500)",
-				"font-sans": "'Inter'",
-				"font-serif": "'Open Sans'",
-				"font-mono": "'Geist Mono'",
-				"base-white": "var(--text-base-white)",
-				"base-black": "var(--text-base-black)",
-				"l1-background": "var(--bg-neutral-dark-1000)",
-				"l2-background": "var(--bg-neutral-dark-900)",
-				"l3-background": "var(--bg-neutral-dark-800)",
-				"l1-background-hover": "var(--bg-neutral-dark-900)",
-				"l2-background-hover": "var(--bg-neutral-dark-700)",
-				"l3-background-hover": "var(--bg-neutral-dark-700)",
-				"l1-foreground": "var(--text-neutral-dark-50)",
-				"l1-foreground-hover": "var(--text-base-white)",
-				"l2-foreground": "var(--text-neutral-dark-100)",
-				"l2-foreground-hover": "var(--text-neutral-dark-50)",
-				"l3-foreground": "var(--text-neutral-dark-200)",
-				"l3-foreground-hover": "var(--text-neutral-dark-300)",
-				"l1-border": "var(--bg-neutral-dark-900)",
-				"l2-border": "var(--bg-neutral-dark-800)",
-				"l3-border": "var(--bg-neutral-dark-700)",
-				"primary-background": "var(--bg-robin-500)",
-				"primary-background-hover": "var(--bg-robin-400)",
-				"primary-foreground": "var(--text-neutral-dark-50)",
-				"primary-foreground-hover": "var(--text-base-white)",
-				"secondary-background": "var(--bg-neutral-dark-900)",
-				"secondary-background-hover": "var(--bg-neutral-dark-700)",
-				"secondary-foreground": "var(--text-neutral-dark-100)",
-				"secondary-foreground-hover": "var(--text-neutral-dark-50)",
-				"secondary-border": "var(--bg-neutral-dark-800)",
-				"success-background": "var(--bg-forest-600)",
-				"success-background-hover": "var(--bg-forest-400)",
-				"success-foreground": "var(--text-neutral-dark-50)",
-				"success-foreground-hover": "var(--text-base-white)",
-				"warning-background": "var(--bg-amber-600)",
-				"warning-background-hover": "var(--bg-amber-400)",
-				"warning-foreground": "var(--text-neutral-dark-50)",
-				"warning-foreground-hover": "var(--text-base-white)",
-				"danger-background": "var(--bg-cherry-500)",
-				"danger-background-hover": "var(--bg-cherry-400)",
-				"danger-foreground": "var(--text-neutral-dark-50)",
-				"danger-foreground-hover": "var(--text-base-white)",
-				"l1-background-transparent": "color-mix(in srgb, var(--bg-neutral-dark-1000), transparent 100%)",
-				"l1-background-60": "color-mix(in srgb, var(--bg-neutral-dark-1000), transparent 40%)",
-				"l2-background-transparent": "color-mix(in srgb, var(--bg-neutral-dark-900), transparent 100%)",
-				"l2-background-60": "color-mix(in srgb, var(--bg-neutral-dark-900), transparent 40%)",
-				"l3-background-transparent": "color-mix(in srgb, var(--bg-neutral-dark-800), transparent 100%)",
-				"l3-background-60": "color-mix(in srgb, var(--bg-neutral-dark-800), transparent 40%)",
-				"callout-primary-background": "color-mix(in srgb, var(--bg-robin-500), transparent 90%)",
-				"callout-primary-border": "color-mix(in srgb, var(--bg-robin-500), transparent 80%)",
-				"callout-primary-title": "var(--bg-robin-400)",
-				"callout-primary-description": "var(--bg-robin-400)",
-				"callout-primary-icon": "var(--bg-robin-300)",
-				"callout-success-background": "color-mix(in srgb, var(--bg-forest-600), transparent 90%)",
-				"callout-success-border": "color-mix(in srgb, var(--bg-forest-600), transparent 80%)",
-				"callout-success-title": "var(--bg-forest-400)",
-				"callout-success-description": "var(--bg-forest-400)",
-				"callout-success-icon": "var(--bg-forest-300)",
-				"callout-warning-background": "color-mix(in srgb, var(--bg-amber-600), transparent 90%)",
-				"callout-warning-border": "color-mix(in srgb, var(--bg-amber-600), transparent 80%)",
-				"callout-warning-title": "var(--bg-amber-400)",
-				"callout-warning-description": "var(--bg-amber-400)",
-				"callout-warning-icon": "var(--bg-amber-300)",
-				"callout-error-background": "color-mix(in srgb, var(--bg-cherry-500), transparent 90%)",
-				"callout-error-border": "color-mix(in srgb, var(--bg-cherry-500), transparent 80%)",
-				"callout-error-title": "var(--bg-cherry-400)",
-				"callout-error-description": "var(--bg-cherry-400)",
-				"callout-error-icon": "var(--bg-cherry-300)",
-				"accent-primary": "var(--bg-robin-500)",
-				"accent-primary-hover": "var(--bg-robin-400)",
-				"accent-primary-foreground": "var(--text-ink-500)",
-				"accent-forest": "var(--bg-forest-500)",
-				"accent-forest-hover": "var(--bg-forest-400)",
-				"accent-forest-foreground": "var(--text-ink-500)",
-				"accent-amber": "var(--bg-amber-500)",
-				"accent-amber-hover": "var(--bg-amber-400)",
-				"accent-amber-foreground": "var(--text-ink-500)",
-				"accent-cherry": "var(--bg-cherry-500)",
-				"accent-cherry-hover": "var(--bg-cherry-400)",
-				"accent-cherry-foreground": "var(--text-ink-500)",
-				"accent-aqua": "var(--bg-aqua-500)",
-				"accent-aqua-hover": "var(--bg-aqua-400)",
-				"accent-aqua-foreground": "var(--text-ink-500)",
-				"accent-sakura": "var(--bg-sakura-500)",
-				"accent-sakura-hover": "var(--bg-sakura-400)",
-				"accent-sakura-foreground": "var(--text-ink-500)",
-				"accent-sienna": "var(--bg-sienna-500)",
-				"accent-sienna-hover": "var(--bg-sienna-400)",
-				"accent-sienna-foreground": "var(--text-ink-500)"
+				"background": {
+					"value": "var(--bg-ink-500)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"foreground": {
+					"value": "var(--text-vanilla-400)",
+					"description": "",
+					"category": "foreground",
+					"group": "legacy"
+				},
+				"card": {
+					"value": "var(--bg-ink-400)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"card-foreground": {
+					"value": "var(--text-vanilla-100)",
+					"description": "",
+					"category": "foreground",
+					"group": "legacy"
+				},
+				"popover": {
+					"value": "var(--bg-ink-400)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"popover-foreground": {
+					"value": "var(--text-vanilla-100)",
+					"description": "",
+					"category": "foreground",
+					"group": "legacy"
+				},
+				"primary": {
+					"value": "var(--bg-robin-500)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"secondary": {
+					"value": "var(--bg-slate-500)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"muted": {
+					"value": "var(--bg-slate-500)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"muted-foreground": {
+					"value": "var(--text-vanilla-400)",
+					"description": "",
+					"category": "foreground",
+					"group": "legacy"
+				},
+				"accent": {
+					"value": "var(--bg-slate-300)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"accent-foreground": {
+					"value": "var(--text-vanilla-100)",
+					"description": "",
+					"category": "foreground",
+					"group": "legacy"
+				},
+				"destructive": {
+					"value": "var(--bg-cherry-500)",
+					"description": "",
+					"category": "background",
+					"group": "legacy"
+				},
+				"destructive-foreground": {
+					"value": "var(--text-ink-500)",
+					"description": "",
+					"category": "foreground",
+					"group": "legacy"
+				},
+				"border": {
+					"value": "var(--bg-slate-400)",
+					"description": "",
+					"category": "border",
+					"group": "legacy"
+				},
+				"input": {
+					"value": "var(--bg-slate-300)",
+					"description": "",
+					"category": "border",
+					"group": "legacy"
+				},
+				"ring": {
+					"value": "var(--bg-robin-500)",
+					"description": "",
+					"category": "border",
+					"group": "legacy"
+				},
+				"radius": {
+					"value": "0.25rem",
+					"description": "",
+					"category": "other",
+					"group": "legacy"
+				},
+				"chart-1": {
+					"value": "var(--bg-robin-400)",
+					"description": "",
+					"category": "background",
+					"group": "charts"
+				},
+				"chart-2": {
+					"value": "var(--bg-robin-500)",
+					"description": "",
+					"category": "background",
+					"group": "charts"
+				},
+				"chart-3": {
+					"value": "var(--bg-robin-600)",
+					"description": "",
+					"category": "background",
+					"group": "charts"
+				},
+				"chart-4": {
+					"value": "var(--bg-slate-200)",
+					"description": "",
+					"category": "background",
+					"group": "charts"
+				},
+				"chart-5": {
+					"value": "var(--bg-slate-300)",
+					"description": "",
+					"category": "background",
+					"group": "charts"
+				},
+				"sidebar": {
+					"value": "var(--bg-slate-500)",
+					"description": "",
+					"category": "background",
+					"group": "sidebar"
+				},
+				"sidebar-foreground": {
+					"value": "var(--text-vanilla-400)",
+					"description": "",
+					"category": "foreground",
+					"group": "sidebar"
+				},
+				"sidebar-primary": {
+					"value": "var(--bg-robin-500)",
+					"description": "",
+					"category": "background",
+					"group": "sidebar"
+				},
+				"sidebar-primary-foreground": {
+					"value": "var(--text-ink-500)",
+					"description": "",
+					"category": "foreground",
+					"group": "sidebar"
+				},
+				"sidebar-accent": {
+					"value": "var(--bg-slate-400)",
+					"description": "",
+					"category": "background",
+					"group": "sidebar"
+				},
+				"sidebar-accent-foreground": {
+					"value": "var(--text-vanilla-400)",
+					"description": "",
+					"category": "foreground",
+					"group": "sidebar"
+				},
+				"sidebar-border": {
+					"value": "var(--bg-slate-500)",
+					"description": "",
+					"category": "border",
+					"group": "sidebar"
+				},
+				"sidebar-ring": {
+					"value": "var(--bg-robin-500)",
+					"description": "",
+					"category": "border",
+					"group": "sidebar"
+				},
+				"font-sans": {
+					"value": "'Inter'",
+					"description": "",
+					"category": "typography",
+					"group": "fonts"
+				},
+				"font-serif": {
+					"value": "'Open Sans'",
+					"description": "",
+					"category": "typography",
+					"group": "fonts"
+				},
+				"font-mono": {
+					"value": "'Geist Mono'",
+					"description": "",
+					"category": "typography",
+					"group": "fonts"
+				},
+				"base-white": {
+					"value": "var(--text-base-white)",
+					"description": "",
+					"category": "foreground",
+					"group": "base"
+				},
+				"base-black": {
+					"value": "var(--text-base-black)",
+					"description": "",
+					"category": "foreground",
+					"group": "base"
+				},
+				"l1-background": {
+					"value": "var(--bg-neutral-dark-1000)",
+					"description": "Primary page background for the outermost container",
+					"usage": "Use for main app shell, page background, and root containers",
+					"dontUse": "Avoid for cards, modals, or nested elements - use l2 or l3 instead",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l2-background": {
+					"value": "var(--bg-neutral-dark-900)",
+					"description": "Secondary background for cards and elevated surfaces",
+					"usage": "Use for cards, panels, sidebars, and first-level nested containers",
+					"dontUse": "Avoid for deeply nested elements - use l3 instead",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l3-background": {
+					"value": "var(--bg-neutral-dark-800)",
+					"description": "Tertiary background for nested elements within cards",
+					"usage": "Use for inputs, dropdowns, and elements nested inside l2 containers",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l1-background-hover": {
+					"value": "var(--bg-neutral-dark-900)",
+					"description": "Hover state for l1-background elements",
+					"usage": "Use for interactive elements on l1 background surfaces",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l2-background-hover": {
+					"value": "var(--bg-neutral-dark-700)",
+					"description": "Hover state for l2-background elements",
+					"usage": "Use for interactive elements on l2 background surfaces",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l3-background-hover": {
+					"value": "var(--bg-neutral-dark-700)",
+					"description": "Hover state for l3-background elements",
+					"usage": "Use for interactive elements on l3 background surfaces",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l1-foreground": {
+					"value": "var(--text-neutral-dark-50)",
+					"description": "Primary text color for l1 backgrounds",
+					"usage": "Use for headings and primary text on l1 surfaces",
+					"category": "foreground",
+					"group": "surface-levels"
+				},
+				"l1-foreground-hover": {
+					"value": "var(--text-base-white)",
+					"description": "Hover text color for interactive elements on l1",
+					"category": "foreground",
+					"group": "surface-levels"
+				},
+				"l2-foreground": {
+					"value": "var(--text-neutral-dark-100)",
+					"description": "Secondary text color for l2 backgrounds",
+					"usage": "Use for body text and secondary content on l2 surfaces",
+					"category": "foreground",
+					"group": "surface-levels"
+				},
+				"l2-foreground-hover": {
+					"value": "var(--text-neutral-dark-50)",
+					"description": "Hover text color for interactive elements on l2",
+					"category": "foreground",
+					"group": "surface-levels"
+				},
+				"l3-foreground": {
+					"value": "var(--text-neutral-dark-200)",
+					"description": "Tertiary text color for l3 backgrounds and muted text",
+					"usage": "Use for captions, labels, and less prominent text",
+					"category": "foreground",
+					"group": "surface-levels"
+				},
+				"l3-foreground-hover": {
+					"value": "var(--text-neutral-dark-300)",
+					"description": "Hover text color for interactive elements on l3",
+					"category": "foreground",
+					"group": "surface-levels"
+				},
+				"l1-border": {
+					"value": "var(--bg-neutral-dark-900)",
+					"description": "Border color for elements on l1 backgrounds",
+					"usage": "Use for dividers and borders separating l1 content",
+					"category": "border",
+					"group": "surface-levels"
+				},
+				"l2-border": {
+					"value": "var(--bg-neutral-dark-800)",
+					"description": "Border color for elements on l2 backgrounds",
+					"usage": "Use for card borders and dividers within cards",
+					"category": "border",
+					"group": "surface-levels"
+				},
+				"l3-border": {
+					"value": "var(--bg-neutral-dark-700)",
+					"description": "Border color for elements on l3 backgrounds",
+					"usage": "Use for input borders and nested element dividers",
+					"category": "border",
+					"group": "surface-levels"
+				},
+				"primary-background": {
+					"value": "var(--bg-robin-500)",
+					"description": "Primary action background color",
+					"usage": "Use for primary buttons, CTAs, and main interactive elements",
+					"category": "background",
+					"group": "actions"
+				},
+				"primary-background-hover": {
+					"value": "var(--bg-robin-400)",
+					"description": "Hover state for primary action elements",
+					"category": "background",
+					"group": "actions"
+				},
+				"primary-foreground": {
+					"value": "var(--text-neutral-dark-50)",
+					"description": "Text color for primary action elements",
+					"usage": "Use for text on primary buttons and CTAs",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"primary-foreground-hover": {
+					"value": "var(--text-base-white)",
+					"description": "Hover text color for primary action elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"secondary-background": {
+					"value": "var(--bg-neutral-dark-900)",
+					"description": "Secondary action background color",
+					"usage": "Use for secondary buttons and less prominent actions",
+					"category": "background",
+					"group": "actions"
+				},
+				"secondary-background-hover": {
+					"value": "var(--bg-neutral-dark-700)",
+					"description": "Hover state for secondary action elements",
+					"category": "background",
+					"group": "actions"
+				},
+				"secondary-foreground": {
+					"value": "var(--text-neutral-dark-100)",
+					"description": "Text color for secondary action elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"secondary-foreground-hover": {
+					"value": "var(--text-neutral-dark-50)",
+					"description": "Hover text color for secondary action elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"secondary-border": {
+					"value": "var(--bg-neutral-dark-800)",
+					"description": "Border color for secondary buttons",
+					"usage": "Use for outlined secondary buttons",
+					"category": "border",
+					"group": "actions"
+				},
+				"success-background": {
+					"value": "var(--bg-forest-600)",
+					"description": "Success action background color",
+					"usage": "Use for success states, confirmations, and positive actions",
+					"category": "background",
+					"group": "actions"
+				},
+				"success-background-hover": {
+					"value": "var(--bg-forest-400)",
+					"description": "Hover state for success elements",
+					"category": "background",
+					"group": "actions"
+				},
+				"success-foreground": {
+					"value": "var(--text-neutral-dark-50)",
+					"description": "Text color for success action elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"success-foreground-hover": {
+					"value": "var(--text-base-white)",
+					"description": "Hover text color for success elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"warning-background": {
+					"value": "var(--bg-amber-600)",
+					"description": "Warning action background color",
+					"usage": "Use for warning states and cautionary actions",
+					"category": "background",
+					"group": "actions"
+				},
+				"warning-background-hover": {
+					"value": "var(--bg-amber-400)",
+					"description": "Hover state for warning elements",
+					"category": "background",
+					"group": "actions"
+				},
+				"warning-foreground": {
+					"value": "var(--text-neutral-dark-50)",
+					"description": "Text color for warning action elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"warning-foreground-hover": {
+					"value": "var(--text-base-white)",
+					"description": "Hover text color for warning elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"danger-background": {
+					"value": "var(--bg-cherry-500)",
+					"description": "Danger action background color",
+					"usage": "Use for destructive actions, errors, and critical warnings",
+					"category": "background",
+					"group": "actions"
+				},
+				"danger-background-hover": {
+					"value": "var(--bg-cherry-400)",
+					"description": "Hover state for danger elements",
+					"category": "background",
+					"group": "actions"
+				},
+				"danger-foreground": {
+					"value": "var(--text-neutral-dark-50)",
+					"description": "Text color for danger action elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"danger-foreground-hover": {
+					"value": "var(--text-base-white)",
+					"description": "Hover text color for danger elements",
+					"category": "foreground",
+					"group": "actions"
+				},
+				"l1-background-transparent": {
+					"value": "color-mix(in srgb, var(--bg-neutral-dark-1000), transparent 100%)",
+					"description": "",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l1-background-60": {
+					"value": "color-mix(in srgb, var(--bg-neutral-dark-1000), transparent 40%)",
+					"description": "",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l2-background-transparent": {
+					"value": "color-mix(in srgb, var(--bg-neutral-dark-900), transparent 100%)",
+					"description": "",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l2-background-60": {
+					"value": "color-mix(in srgb, var(--bg-neutral-dark-900), transparent 40%)",
+					"description": "",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l3-background-transparent": {
+					"value": "color-mix(in srgb, var(--bg-neutral-dark-800), transparent 100%)",
+					"description": "",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"l3-background-60": {
+					"value": "color-mix(in srgb, var(--bg-neutral-dark-800), transparent 40%)",
+					"description": "",
+					"category": "background",
+					"group": "surface-levels"
+				},
+				"callout-primary-background": {
+					"value": "color-mix(in srgb, var(--bg-robin-500), transparent 90%)",
+					"description": "Background for informational callout boxes",
+					"usage": "Use for info callouts, tips, and general announcements",
+					"category": "background",
+					"group": "callouts"
+				},
+				"callout-primary-border": {
+					"value": "color-mix(in srgb, var(--bg-robin-500), transparent 80%)",
+					"description": "Border for informational callout boxes",
+					"category": "border",
+					"group": "callouts"
+				},
+				"callout-primary-title": {
+					"value": "var(--bg-robin-400)",
+					"description": "Title text color for informational callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-primary-description": {
+					"value": "var(--bg-robin-400)",
+					"description": "Description text color for informational callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-primary-icon": {
+					"value": "var(--bg-robin-300)",
+					"description": "Icon color for informational callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-success-background": {
+					"value": "color-mix(in srgb, var(--bg-forest-600), transparent 90%)",
+					"description": "Background for success callout boxes",
+					"usage": "Use for success messages and positive confirmations",
+					"category": "background",
+					"group": "callouts"
+				},
+				"callout-success-border": {
+					"value": "color-mix(in srgb, var(--bg-forest-600), transparent 80%)",
+					"description": "Border for success callout boxes",
+					"category": "border",
+					"group": "callouts"
+				},
+				"callout-success-title": {
+					"value": "var(--bg-forest-400)",
+					"description": "Title text color for success callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-success-description": {
+					"value": "var(--bg-forest-400)",
+					"description": "Description text color for success callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-success-icon": {
+					"value": "var(--bg-forest-300)",
+					"description": "Icon color for success callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-warning-background": {
+					"value": "color-mix(in srgb, var(--bg-amber-600), transparent 90%)",
+					"description": "Background for warning callout boxes",
+					"usage": "Use for warning messages and cautionary information",
+					"category": "background",
+					"group": "callouts"
+				},
+				"callout-warning-border": {
+					"value": "color-mix(in srgb, var(--bg-amber-600), transparent 80%)",
+					"description": "Border for warning callout boxes",
+					"category": "border",
+					"group": "callouts"
+				},
+				"callout-warning-title": {
+					"value": "var(--bg-amber-400)",
+					"description": "Title text color for warning callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-warning-description": {
+					"value": "var(--bg-amber-400)",
+					"description": "Description text color for warning callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-warning-icon": {
+					"value": "var(--bg-amber-300)",
+					"description": "Icon color for warning callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-error-background": {
+					"value": "color-mix(in srgb, var(--bg-cherry-500), transparent 90%)",
+					"description": "Background for error callout boxes",
+					"usage": "Use for error messages and critical information",
+					"category": "background",
+					"group": "callouts"
+				},
+				"callout-error-border": {
+					"value": "color-mix(in srgb, var(--bg-cherry-500), transparent 80%)",
+					"description": "Border for error callout boxes",
+					"category": "border",
+					"group": "callouts"
+				},
+				"callout-error-title": {
+					"value": "var(--bg-cherry-400)",
+					"description": "Title text color for error callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-error-description": {
+					"value": "var(--bg-cherry-400)",
+					"description": "Description text color for error callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"callout-error-icon": {
+					"value": "var(--bg-cherry-300)",
+					"description": "Icon color for error callouts",
+					"category": "foreground",
+					"group": "callouts"
+				},
+				"accent-primary": {
+					"value": "var(--bg-robin-500)",
+					"description": "Primary brand accent color",
+					"usage": "Use for links, highlights, and brand elements",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-primary-hover": {
+					"value": "var(--bg-robin-400)",
+					"description": "Hover state for primary accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-primary-foreground": {
+					"value": "var(--text-ink-500)",
+					"description": "Text color on primary accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				},
+				"accent-forest": {
+					"value": "var(--bg-forest-500)",
+					"description": "Green accent for success and positive indicators",
+					"usage": "Use for success badges, positive trends, and status indicators",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-forest-hover": {
+					"value": "var(--bg-forest-400)",
+					"description": "Hover state for forest accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-forest-foreground": {
+					"value": "var(--text-ink-500)",
+					"description": "Text color on forest accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				},
+				"accent-amber": {
+					"value": "var(--bg-amber-500)",
+					"description": "Yellow/orange accent for warnings and attention",
+					"usage": "Use for warning badges, pending states, and attention indicators",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-amber-hover": {
+					"value": "var(--bg-amber-400)",
+					"description": "Hover state for amber accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-amber-foreground": {
+					"value": "var(--text-ink-500)",
+					"description": "Text color on amber accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				},
+				"accent-cherry": {
+					"value": "var(--bg-cherry-500)",
+					"description": "Red accent for errors and critical states",
+					"usage": "Use for error badges, negative trends, and critical indicators",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-cherry-hover": {
+					"value": "var(--bg-cherry-400)",
+					"description": "Hover state for cherry accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-cherry-foreground": {
+					"value": "var(--text-ink-500)",
+					"description": "Text color on cherry accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				},
+				"accent-aqua": {
+					"value": "var(--bg-aqua-500)",
+					"description": "Cyan/teal accent for informational elements",
+					"usage": "Use for info badges, links, and data visualization",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-aqua-hover": {
+					"value": "var(--bg-aqua-400)",
+					"description": "Hover state for aqua accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-aqua-foreground": {
+					"value": "var(--text-ink-500)",
+					"description": "Text color on aqua accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				},
+				"accent-sakura": {
+					"value": "var(--bg-sakura-500)",
+					"description": "Pink accent for decorative elements",
+					"usage": "Use for tags, labels, and data visualization variety",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-sakura-hover": {
+					"value": "var(--bg-sakura-400)",
+					"description": "Hover state for sakura accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-sakura-foreground": {
+					"value": "var(--text-ink-500)",
+					"description": "Text color on sakura accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				},
+				"accent-sienna": {
+					"value": "var(--bg-sienna-500)",
+					"description": "Brown/orange accent for earthy elements",
+					"usage": "Use for tags, labels, and data visualization variety",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-sienna-hover": {
+					"value": "var(--bg-sienna-400)",
+					"description": "Hover state for sienna accent",
+					"category": "background",
+					"group": "accents"
+				},
+				"accent-sienna-foreground": {
+					"value": "var(--text-ink-500)",
+					"description": "Text color on sienna accent backgrounds",
+					"category": "foreground",
+					"group": "accents"
+				}
 			}
 		}
 	}

--- a/src/types/Style.ts
+++ b/src/types/Style.ts
@@ -1,7 +1,7 @@
 /**
  * Semantic Token Constants
  * DO NOT EDIT DIRECTLY - This file is auto-generated
- * Generated on Mon, 02 Feb 2026 06:36:25 GMT
+ * Generated on Fri, 27 Feb 2026 14:32:24 GMT
  */
 
 export const Style = {

--- a/src/types/StyleTailwind.ts
+++ b/src/types/StyleTailwind.ts
@@ -1,7 +1,7 @@
 /**
  * Semantic Token Tailwind Config
  * DO NOT EDIT DIRECTLY - This file is auto-generated
- * Generated on Mon, 02 Feb 2026 06:36:25 GMT
+ * Generated on Fri, 27 Feb 2026 14:32:24 GMT
  */
 
 export const StyleTailwind = {


### PR DESCRIPTION
Expanded the semanticTokens to add documentation about some tokens, how to use and when not use it.

This is used to generate the following page on Styrybook of Periscope:

<img width="1088" height="818" alt="image" src="https://github.com/user-attachments/assets/19f27971-6a16-421c-8652-b670effe268c" />
