### PR TITLE
fix(husky): improve commit-msg script for CI compatibility

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,13 +1,20 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm commitlint --edit $1
+pnpm commitlint --edit "$1"
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
 
-color_red="$(tput setaf 1)"
-bold="$(tput bold)"
-reset="$(tput sgr0)"
+color_red=""
+bold=""
+reset=""
+
+# In CI / non-interactive shells `$TERM` may be unset and `tput` will fail.
+if [ -t 1 ] && [ -n "${TERM:-}" ] && command -v tput >/dev/null 2>&1; then
+  color_red="$(tput setaf 1)"
+  bold="$(tput bold)"
+  reset="$(tput sgr0)"
+fi
 
 if [ "$branch" = "main" ]; then
   echo "${color_red}${bold}You can't commit directly to the main branch${reset}"


### PR DESCRIPTION
Updated the commit-msg script to handle non-interactive shells by checking for the presence of the TERM variable before using tput for color formatting. This ensures that the script functions correctly in CI environments. Additionally, wrapped the argument to commitlint in quotes for better handling of file names.