### PR TITLE
fix: use forest green for success-foreground token

### DIFF
--- a/.changeset/honest-needles-switch.md
+++ b/.changeset/honest-needles-switch.md
@@ -1,5 +1,0 @@
----
-'@signozhq/design-tokens': patch
----
-
-Expose semantic tokens with docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @signoz/design-tokens
 
+## 2.1.7
+
+### Patch Changes
+
+- ff64e30: Expose semantic tokens with docs
+- correct dark-mode success-foreground token
+
 ## 2.1.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@signozhq/design-tokens",
-	"version": "2.1.6",
+	"version": "2.1.7",
 	"type": "module",
 	"main": "./dist/design-tokens.js",
 	"module": "./dist/design-tokens.js",

--- a/src/themes/signoz-tokens.css
+++ b/src/themes/signoz-tokens.css
@@ -1,7 +1,7 @@
 /**
  * Signoz Theme Tokens
  * DO NOT EDIT DIRECTLY - This file is auto-generated
- * Generated on Tue, 28 Apr 2026 18:30:26 GMT
+ * Generated on Tue, 02 Jun 2026 15:48:23 GMT
  */
 
 [data-theme='default'] {
@@ -69,8 +69,8 @@
 	--secondary-border: var(--bg-neutral-light-800);
 	--success-background: var(--bg-forest-600);
 	--success-background-hover: var(--bg-forest-400);
-	--success-foreground: var(--text-neutral-light-50);
-	--success-foreground-hover: var(--text-base-black);
+	--success-foreground: var(--text-forest-500);
+	--success-foreground-hover: var(--text-forest-400);
 	--warning-background: var(--bg-amber-600);
 	--warning-background-hover: var(--bg-amber-400);
 	--warning-foreground: var(--text-neutral-light-50);
@@ -289,8 +289,8 @@
 	--secondary-border: var(--bg-neutral-dark-800);
 	--success-background: var(--bg-forest-500);
 	--success-background-hover: var(--bg-forest-400);
-	--success-foreground: var(--text-neutral-dark-1000);
-	--success-foreground-hover: var(--text-base-black);
+	--success-foreground: var(--text-forest-500);
+	--success-foreground-hover: var(--text-forest-400);
 	--warning-background: var(--bg-amber-500);
 	--warning-background-hover: var(--bg-amber-400);
 	--warning-foreground: var(--text-neutral-dark-1000);

--- a/src/tokens/semantic-tokens.json
+++ b/src/tokens/semantic-tokens.json
@@ -398,13 +398,13 @@
 					"group": "actions"
 				},
 				"success-foreground": {
-					"value": "var(--text-neutral-light-50)",
+					"value": "var(--text-forest-500)",
 					"description": "Text color for success action elements",
 					"category": "foreground",
 					"group": "actions"
 				},
 				"success-foreground-hover": {
-					"value": "var(--text-base-black)",
+					"value": "var(--text-forest-400)",
 					"description": "Hover text color for success elements",
 					"category": "foreground",
 					"group": "actions"
@@ -1296,13 +1296,13 @@
 					"group": "actions"
 				},
 				"success-foreground": {
-					"value": "var(--text-neutral-dark-1000)",
+					"value": "var(--text-forest-500)",
 					"description": "Text color for success action elements",
 					"category": "foreground",
 					"group": "actions"
 				},
 				"success-foreground-hover": {
-					"value": "var(--text-base-black)",
+					"value": "var(--text-forest-400)",
 					"description": "Hover text color for success elements",
 					"category": "foreground",
 					"group": "actions"


### PR DESCRIPTION
## Summary

`--success-foreground` was a **neutral** color (`--text-neutral-*`). UI migrated to consume it for success text — e.g. the AlertHistory **StatsCard** delta pill (`color: var(--success-foreground)`) — therefore lost the green it had before the component migration, which used `--bg-forest-500` directly.

This points the token at the brand green so success text renders green again:

| Token | Before | After |
|---|---|---|
| `--success-foreground` (light + dark) | neutral (`--text-neutral-*`) | **`--text-forest-500`** (#25e192) |
| `--success-foreground-hover` (light + dark) | `--text-base-black` / `--text-base-white` | **`--text-forest-400`** (#50e7a7) |

`--text-forest-500` is the text-category twin of the old `--bg-forest-500`, so it restores the pre-migration appearance.

## How it was changed
Edited the **`src/tokens/semantic-tokens.json`** source of truth and **regenerated** `src/themes/signoz-tokens.css` via `pnpm generate-tokens` (the CSS is auto-generated — `DO NOT EDIT DIRECTLY`). `Style.ts` / `StyleTailwind.ts` are unaffected (they map token *names*, which are unchanged).

## Notes for reviewers
- This makes `--success-foreground` semantic-colored (green), which **diverges from `--danger-foreground`** (still neutral). If the intent is for all action foregrounds to be neutral, the fix belongs in the consuming UI instead — flagging so we pick one direction deliberately.
- **Light mode:** `--text-forest-500` (#25e192) is a bright green; on light surfaces it’s lower-contrast. If accessibility on light backgrounds matters here, the light value may want a darker forest (e.g. `--text-forest-700`). Happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
